### PR TITLE
Create .gitattributes to solve line ending problem

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
I think this should be the best solution to the line ending issue on Windows. As the user shouldn't have to configure the line ending in a cross-platform project.