### PR TITLE
feat: Yellow status indicator for a pruned peer

### DIFF
--- a/src/app/components/tangle/PeersSummaryState.ts
+++ b/src/app/components/tangle/PeersSummaryState.ts
@@ -13,4 +13,14 @@ export interface PeersSummaryState {
      * Hide any secure details.
      */
     blindMode: boolean;
+
+    /**
+     * Confirmed milestone index.
+     */
+    cmi?: number;
+
+    /**
+     * Latest milestone index.
+     */
+    lmi?: number;
 }

--- a/src/app/routes/Peer.tsx
+++ b/src/app/routes/Peer.tsx
@@ -103,7 +103,7 @@ class Peer extends AsyncComponent<RouteComponentProps<PeerRouteProps>, PeerState
                 for (const allDataPeers of allData) {
                     if (allDataPeers) {
                         const peer = allDataPeers.find(p => p.id === this.props.match.params.id);
-                        const lmi = this.state.lmi ? this.state.lmi : 0;
+                        const lmi = this.state.nodeLmi ? this.state.nodeLmi : 0;
 
                         if (peer) {
                             alias = peer.alias;
@@ -172,12 +172,12 @@ class Peer extends AsyncComponent<RouteComponentProps<PeerRouteProps>, PeerState
                     const cmi = data.cmi;
                     const lmi = data.lmi;
 
-                    if (cmi && cmi !== this.state.cmi) {
-                        this.setState({ cmi });
+                    if (cmi && cmi !== this.state.nodeCmi) {
+                        this.setState({ nodeCmi: cmi });
                     }
 
-                    if (lmi && lmi !== this.state.lmi) {
-                        this.setState({ lmi });
+                    if (lmi && lmi !== this.state.nodeLmi) {
+                        this.setState({ nodeLmi: lmi });
                     }
                 }
             }
@@ -252,8 +252,8 @@ class Peer extends AsyncComponent<RouteComponentProps<PeerRouteProps>, PeerState
                                     Relation:&nbsp;
                                     {`${this.state.relation.slice(0, 1).toUpperCase()}${this.state.relation.slice(1)}`}
                                 </p>
-                                {this.state.isSynced && this.state.cmi &&
-                                Number(this.state.pruningIndex) > this.state.cmi && (
+                                {this.state.isSynced && this.state.nodeCmi &&
+                                Number(this.state.pruningIndex) > this.state.nodeCmi && (
                                     <p className="secondary warning margin-t-t">
                                         Warning:&nbsp; History of peer not sufficient to sync from.
                                         Consider using a newer snapshot if all peers have the same status.

--- a/src/app/routes/Peer.tsx
+++ b/src/app/routes/Peer.tsx
@@ -252,7 +252,7 @@ class Peer extends AsyncComponent<RouteComponentProps<PeerRouteProps>, PeerState
                                     Relation:&nbsp;
                                     {`${this.state.relation.slice(0, 1).toUpperCase()}${this.state.relation.slice(1)}`}
                                 </p>
-                                {this.state.isSynced && this.state.nodeCmi &&
+                                {this.state.nodeCmi &&
                                 Number(this.state.pruningIndex) > this.state.nodeCmi && (
                                     <p className="secondary warning margin-t-t">
                                         Warning:&nbsp; History of peer not sufficient to sync from.

--- a/src/app/routes/PeerState.ts
+++ b/src/app/routes/PeerState.ts
@@ -23,12 +23,12 @@ export interface PeerState {
     blindMode: boolean;
 
     /**
-     * Nodes confirmed milestone index.
+     * Confirmed milestone index of the node.
      */
-    cmi?: number;
+    nodeCmi?: number;
 
     /**
-     * Nodes latest milestone index.
+     * Latest milestone index of the node.
      */
-    lmi?: number;
+    nodeLmi?: number;
 }

--- a/src/app/routes/PeerState.ts
+++ b/src/app/routes/PeerState.ts
@@ -21,4 +21,14 @@ export interface PeerState {
      * Hide any secure details.
      */
     blindMode: boolean;
+
+    /**
+     * Nodes confirmed milestone index.
+     */
+    cmi?: number;
+
+    /**
+     * Nodes latest milestone index.
+     */
+    lmi?: number;
 }

--- a/src/app/routes/PeersState.ts
+++ b/src/app/routes/PeersState.ts
@@ -60,4 +60,14 @@ export interface PeersState {
      * Hide any secure details.
      */
     blindMode: boolean;
+
+    /**
+     * Confirmed milestone index.
+     */
+    cmi?: number;
+
+    /**
+     * Latest milestone index.
+     */
+    lmi?: number;
 }


### PR DESCRIPTION
# Description of change

Added a yellow status indicator for a peer whose pruning index is higher than the node's CMI.
Fixes #46.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Change was tested by using an old snapshot.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

