### PR TITLE
Fix: Pagination for Outputs on Block page

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -29,13 +29,15 @@ import NavMenu from "./components/layout/NavMenu";
 import NavPanel from "./components/layout/NavPanel";
 import Explorer from "./routes/Explorer";
 import Address from "./routes/explorer/Address";
-import { AddressRouteProps } from "./routes/explorer/AddressRouteProps";
+import { AddressProps } from "./routes/explorer/AddressProps";
 import Block from "./routes/explorer/Block";
-import { BlockRouteProps } from "./routes/explorer/BlockRouteProps";
+import { BlockProps } from "./routes/explorer/BlockProps";
 import Milestone from "./routes/explorer/Milestone";
-import { MilestoneRouteProps } from "./routes/explorer/MilestoneRouteProps";
+import { MilestoneProps } from "./routes/explorer/MilestoneProps";
 import OutputRoute from "./routes/explorer/OutputRoute";
 import { OutputRouteProps } from "./routes/explorer/OutputRouteProps";
+import OutputsRoute from "./routes/explorer/OutputsRoute";
+import { OutputsRouteProps } from "./routes/explorer/OutputsRouteProps";
 import Home from "./routes/Home";
 import Login from "./routes/Login";
 import Peer from "./routes/Peer";
@@ -377,23 +379,28 @@ class App extends AsyncComponent<RouteComponentProps, AppState> {
                                     />
                                     <Route
                                         path="/explorer/block/:blockId"
-                                        component={(props: RouteComponentProps<BlockRouteProps>) =>
+                                        component={(props: RouteComponentProps<BlockProps>) =>
                                             (<Block {...props} />)}
                                     />
                                     <Route
                                         path="/explorer/milestone/:milestoneIndex"
-                                        component={(props: RouteComponentProps<MilestoneRouteProps>) =>
+                                        component={(props: RouteComponentProps<MilestoneProps>) =>
                                             (<Milestone {...props} />)}
                                     />
                                     <Route
                                         path="/explorer/address/:address"
-                                        component={(props: RouteComponentProps<AddressRouteProps>) =>
+                                        component={(props: RouteComponentProps<AddressProps>) =>
                                             (<Address {...props} />)}
                                     />
                                     <Route
                                         path="/explorer/output/:outputId"
                                         component={(props: RouteComponentProps<OutputRouteProps>) =>
                                             (<OutputRoute {...props} />)}
+                                    />
+                                    <Route
+                                        path="/explorer/outputs/:tag"
+                                        component={(props: RouteComponentProps<OutputsRouteProps>) =>
+                                            (<OutputsRoute {...props} />)}
                                     />
                                     <Route
                                         path="/visualizer"

--- a/src/app/components/layout/Pagination.tsx
+++ b/src/app/components/layout/Pagination.tsx
@@ -88,11 +88,12 @@ class Pagination extends Component<PaginationProps, PaginationState> {
             >
                 <li
                     className={classNames("pagination-item", {
-                        disabled: this.props.currentPage < 11,
+                        disabled: this.props.currentPage === 1,
                         "d-none": this.state.isMobile
                     })}
                     onClick={() => {
-                        this.props.onPageChange(this.props.currentPage - 10);
+                        const page = this.props.currentPage < 11 ? 1 : this.props.currentPage - 10;
+                        this.props.onPageChange(page);
                     }}
                 >
                     <div className="arrow left" />
@@ -137,11 +138,14 @@ class Pagination extends Component<PaginationProps, PaginationState> {
                 </li>
                 <li
                     className={classNames("pagination-item", {
-                        disabled: this.props.currentPage > this.state.lastPage - 10,
+                        disabled: this.props.currentPage === this.state.lastPage,
                         "d-none": this.state.isMobile
                     })}
                     onClick={() => {
-                        this.props.onPageChange(this.props.currentPage + 10);
+                        const page = this.props.currentPage > this.state.lastPage - 10
+                                ? this.state.lastPage
+                                : this.props.currentPage + 10;
+                        this.props.onPageChange(page);
                     }}
                 >
                     <div className="arrow right" />
@@ -165,7 +169,7 @@ class Pagination extends Component<PaginationProps, PaginationState> {
         const minPageRangeCount: number = this.props.siblingsCount + 5;
 
         if (minPageRangeCount >= totalPageCount) {
-            paginationRange = this.range(1, totalPageCount);
+            return this.range(1, totalPageCount);
         }
 
         const leftSiblingIndex = Math.max(this.props.currentPage - this.props.siblingsCount, 1);

--- a/src/app/components/tangle/Feature.tsx
+++ b/src/app/components/tangle/Feature.tsx
@@ -24,12 +24,16 @@ class FeatureBlock extends Component<FeatureProps, FeatureState> {
         let hexData;
         let utf8Data;
         let jsonData;
+        let dataLabel;
 
-        if (this.props.feature.type === METADATA_FEATURE_TYPE) {
-            const matchHexData = this.props.feature.data.match(/.{1,2}/g);
+        if (this.props.feature.type === METADATA_FEATURE_TYPE || this.props.feature.type === TAG_FEATURE_TYPE) {
+            const data = this.props.feature.type === TAG_FEATURE_TYPE
+                            ? this.props.feature.tag : this.props.feature.data;
+            const matchHexData = data.match(/.{1,2}/g);
 
-            hexData = matchHexData ? matchHexData.join(" ") : this.props.feature.data;
-            utf8Data = Converter.hexToUtf8(this.props.feature.data);
+            dataLabel = this.props.feature.type === METADATA_FEATURE_TYPE ? "Data" : "Tag";
+            hexData = matchHexData ? matchHexData.join(" ") : data;
+            utf8Data = Converter.hexToUtf8(data);
 
             try {
                 jsonData = JSON.stringify(JSON.parse(utf8Data), undefined, "  ");
@@ -41,7 +45,8 @@ class FeatureBlock extends Component<FeatureProps, FeatureState> {
             showDetails: false,
             utf8Data,
             hexData,
-            jsonData
+            jsonData,
+            dataLabel
         };
     }
 
@@ -80,12 +85,13 @@ class FeatureBlock extends Component<FeatureProps, FeatureState> {
                                 address={this.props.feature.address}
                             />
                         )}
-                        {this.props.feature.type === METADATA_FEATURE_TYPE && (
+                        {(this.props.feature.type === METADATA_FEATURE_TYPE ||
+                        this.props.feature.type === TAG_FEATURE_TYPE) && (
                             <React.Fragment>
                                 {!this.state.jsonData && this.state.utf8Data && (
                                     <React.Fragment>
-                                        <div className="card--label row bottom spread">
-                                            <span className="margin-r-t">Data UTF8</span>
+                                        <div className="card--label row middle">
+                                            <span className="margin-r-t">{this.state.dataLabel} UTF8</span>
                                             <BlockButton
                                                 onClick={() => ClipboardHelper.copy(
                                                     this.state.utf8Data
@@ -101,8 +107,8 @@ class FeatureBlock extends Component<FeatureProps, FeatureState> {
                                 )}
                                 {this.state.jsonData && (
                                     <React.Fragment>
-                                        <div className="card--label row bottom spread">
-                                            Data JSON
+                                        <div className="card--label row middle">
+                                            {this.state.dataLabel} JSON
                                             <BlockButton
                                                 onClick={() => ClipboardHelper.copy(
                                                     this.state.jsonData
@@ -119,7 +125,7 @@ class FeatureBlock extends Component<FeatureProps, FeatureState> {
                                 {this.state.hexData && (
                                     <React.Fragment>
                                         <div className="card--label row middle">
-                                            <span className="margin-r-t">Data Hex</span>
+                                            <span className="margin-r-t">{this.state.dataLabel} Hex</span>
                                             <BlockButton
                                                 onClick={() => ClipboardHelper.copy(
                                                     this.state.hexData?.replace(/ /g, "")
@@ -133,16 +139,6 @@ class FeatureBlock extends Component<FeatureProps, FeatureState> {
                                         </div>
                                     </React.Fragment>
                                 )}
-                            </React.Fragment>
-                        )}
-                        {this.props.feature.type === TAG_FEATURE_TYPE && (
-                            <React.Fragment>
-                                <div className="card--label">
-                                    Tag:
-                                </div>
-                                <div className="card--value row">
-                                    {this.props.feature.tag}
-                                </div>
                             </React.Fragment>
                         )}
                     </div>

--- a/src/app/components/tangle/FeatureState.ts
+++ b/src/app/components/tangle/FeatureState.ts
@@ -18,4 +18,9 @@ export interface FeatureState {
      * JSON view of data.
      */
     jsonData?: string;
+
+    /**
+     * Label for metadata or tag feature.
+     */
+    dataLabel?: string;
 }

--- a/src/app/components/tangle/Output.tsx
+++ b/src/app/components/tangle/Output.tsx
@@ -36,6 +36,20 @@ class Output extends Component<OutputProps, OutputState> {
     }
 
     /**
+     * The component updated.
+     * @param prevProps The previous properties.
+     */
+    public componentDidUpdate(prevProps: OutputProps): void {
+        if (prevProps !== this.props) {
+            this.setState({
+                isGenesis: (this.isOutputResponse(this.props.output))
+                            ? this.props.output.metadata.blockId === "0".repeat(64) : false,
+                output: (this.isOutputResponse(this.props.output)) ? this.props.output.output : this.props.output
+            });
+        }
+    }
+
+    /**
      * Render the component.
      * @returns The node to render.
      */
@@ -227,19 +241,19 @@ class Output extends Component<OutputProps, OutputState> {
                                                 Minted tokens:
                                             </div>
                                             <div className="card--value row">
-                                                {this.state.output.tokenScheme.mintedTokens}
+                                                {Number.parseInt(this.state.output.tokenScheme.mintedTokens, 16)}
                                             </div>
                                             <div className="card--label">
                                                 Melted tokens:
                                             </div>
                                             <div className="card--value row">
-                                                {this.state.output.tokenScheme.meltedTokens}
+                                                {Number.parseInt(this.state.output.tokenScheme.meltedTokens, 16)}
                                             </div>
                                             <div className="card--label">
                                                 Maximum supply:
                                             </div>
                                             <div className="card--value row">
-                                                {this.state.output.tokenScheme.maximumSupply}
+                                                {Number.parseInt(this.state.output.tokenScheme.maximumSupply, 16)}
                                             </div>
                                         </React.Fragment>
                                     )}

--- a/src/app/components/tangle/Token.tsx
+++ b/src/app/components/tangle/Token.tsx
@@ -56,7 +56,7 @@ class Token extends Component<TokenProps, TokenState> {
                             Amount
                         </div>
                         <div className="card--value card--value__mono">
-                            {this.props.token.amount}
+                            {Number.parseInt(this.props.token.amount, 16)}
                         </div>
                     </div>
                 )}

--- a/src/app/components/tangle/TransactionPayloadState.ts
+++ b/src/app/components/tangle/TransactionPayloadState.ts
@@ -1,7 +1,6 @@
 import { AddressTypes } from "@iota/iota.js";
 
 export interface TransactionPayloadState {
-
     /**
      * The unlock addresses for the transactions.
      */
@@ -11,4 +10,24 @@ export interface TransactionPayloadState {
      * The transaction id.
      */
     transactionId: string;
+
+    /**
+     * The current outputs page.
+     */
+    currentOutputsPage: number;
+
+    /**
+     * The outputs page size.
+     */
+    outputsPageSize: number;
+
+    /**
+     * The current inputs page.
+     */
+    currentInputsPage: number;
+
+    /**
+     * The inputs page size.
+     */
+    inputsPageSize: number;
 }

--- a/src/app/routes/Search.tsx
+++ b/src/app/routes/Search.tsx
@@ -131,7 +131,7 @@ class Search extends AsyncComponent<RouteComponentProps<SearchRouteProps>, Searc
         if (query.length > 0) {
             this.setState({ statusBusy: true }, async () => {
                 const tangleService = ServiceFactory.get<TangleService>("tangle");
-                const response = await tangleService.search(query);
+                const response = await tangleService.search({ query });
 
                 let redirect = "";
 
@@ -158,9 +158,12 @@ class Search extends AsyncComponent<RouteComponentProps<SearchRouteProps>, Searc
                             objParam = Converter.bytesToHex(Blake2b.sum256(writeStream.finalBytes()), true);
                         } else if (response?.address) {
                             objType = "address";
+                            objParam = response.address.bech32 ?? objParam;
                         } else if (response.outputId) {
                             objType = "output";
                             objParam = response.outputId;
+                        } else if (response.outputs) {
+                            objType = "outputs";
                         } else if (response.milestone) {
                             objType = "milestone";
                             objParam = response.milestone.index.toString();

--- a/src/app/routes/explorer/AddressProps.ts
+++ b/src/app/routes/explorer/AddressProps.ts
@@ -1,4 +1,4 @@
-export interface AddressRouteProps {
+export interface AddressProps {
     /**
      * The address to lookup.
      */

--- a/src/app/routes/explorer/AddressState.ts
+++ b/src/app/routes/explorer/AddressState.ts
@@ -1,5 +1,6 @@
 import { IOutputResponse } from "@iota/iota.js";
 import { IAddressDetails } from "../../../models/IAddressDetails";
+import { IAssociatedOutput } from "../../../models/tangle/IAssociatedOutputsResponse";
 
 export interface AddressState {
     /**
@@ -8,9 +9,19 @@ export interface AddressState {
     address?: IAddressDetails;
 
     /**
-     * The address balance.
+     * The outputs for the address.
      */
-    balance?: number;
+    outputs: IAssociatedOutput[];
+
+    /**
+     * Nft output details.
+     */
+    nft?: IOutputResponse & { outputId: string };
+
+    /**
+     * Alias output details.
+     */
+    alias?: IOutputResponse & { outputId: string };
 
     /**
      * Is the component status busy.
@@ -21,26 +32,6 @@ export interface AddressState {
      * The status.
      */
     status: string;
-
-    /**
-     * The output ids for the address.
-     */
-    outputIds?: string[];
-
-    /**
-     * The outputs for the address.
-     */
-    outputs?: IOutputResponse[];
-
-    /**
-     * Format the amount in full.
-     */
-    formatFull: boolean;
-
-    /**
-     * Show native tokens.
-     */
-    showTokens: boolean;
 
     /**
      * The current page.

--- a/src/app/routes/explorer/Block.tsx
+++ b/src/app/routes/explorer/Block.tsx
@@ -19,13 +19,13 @@ import MilestonePayload from "../../components/tangle/MilestonePayload";
 import TaggedDataPayload from "../../components/tangle/TaggedDataPayload";
 import TransactionPayload from "../../components/tangle/TransactionPayload";
 import "./Block.scss";
-import { BlockRouteProps } from "./BlockRouteProps";
+import { BlockProps } from "./BlockProps";
 import { BlockState } from "./BlockState";
 
 /**
  * Component which will show the block page.
  */
-class Block extends AsyncComponent<RouteComponentProps<BlockRouteProps>, BlockState> {
+class Block extends AsyncComponent<RouteComponentProps<BlockProps>, BlockState> {
     /**
      * Service for tangle requests.
      */
@@ -40,7 +40,7 @@ class Block extends AsyncComponent<RouteComponentProps<BlockRouteProps>, BlockSt
      * Create a new instance of Block.
      * @param props The props.
      */
-    constructor(props: RouteComponentProps<BlockRouteProps>) {
+    constructor(props: RouteComponentProps<BlockProps>) {
         super(props);
 
         this._tangleService = ServiceFactory.get<TangleService>("tangle");
@@ -57,7 +57,7 @@ class Block extends AsyncComponent<RouteComponentProps<BlockRouteProps>, BlockSt
     public async componentDidMount(): Promise<void> {
         super.componentDidMount();
 
-        const result = await this._tangleService.search(this.props.match.params.blockId);
+        const result = await this._tangleService.search({ query: this.props.match.params.blockId });
 
         if (result?.block) {
             const writeStream = new WriteStream();

--- a/src/app/routes/explorer/BlockProps.ts
+++ b/src/app/routes/explorer/BlockProps.ts
@@ -1,4 +1,4 @@
-export interface BlockRouteProps {
+export interface BlockProps {
     /**
      * The block to lookup.
      */

--- a/src/app/routes/explorer/Milestone.scss
+++ b/src/app/routes/explorer/Milestone.scss
@@ -1,4 +1,3 @@
-@import '../../../scss/fonts';
 @import '../../../scss/variables';
 @import '../../../scss/media-queries';
 

--- a/src/app/routes/explorer/Milestone.tsx
+++ b/src/app/routes/explorer/Milestone.tsx
@@ -10,13 +10,13 @@ import { FormatHelper } from "../../../utils/formatHelper";
 import AsyncComponent from "../../components/layout/AsyncComponent";
 import BlockButton from "../../components/layout/BlockButton";
 import "./Milestone.scss";
-import { MilestoneRouteProps } from "./MilestoneRouteProps";
+import { MilestoneProps } from "./MilestoneProps";
 import { MilestoneState } from "./MilestoneState";
 
 /**
  * Component which will show the milestone page.
  */
-class Milestone extends AsyncComponent<RouteComponentProps<MilestoneRouteProps>, MilestoneState> {
+class Milestone extends AsyncComponent<RouteComponentProps<MilestoneProps>, MilestoneState> {
     /**
      * Service for tangle requests.
      */
@@ -26,7 +26,7 @@ class Milestone extends AsyncComponent<RouteComponentProps<MilestoneRouteProps>,
      * Create a new instance of Milestone.
      * @param props The props.
      */
-    constructor(props: RouteComponentProps<MilestoneRouteProps>) {
+    constructor(props: RouteComponentProps<MilestoneProps>) {
         super(props);
 
         this._tangleService = ServiceFactory.get<TangleService>("tangle");

--- a/src/app/routes/explorer/MilestoneProps.ts
+++ b/src/app/routes/explorer/MilestoneProps.ts
@@ -1,4 +1,4 @@
-export interface MilestoneRouteProps {
+export interface MilestoneProps {
     /**
      * The milestone to lookup.
      */

--- a/src/app/routes/explorer/OutputsRoute.scss
+++ b/src/app/routes/explorer/OutputsRoute.scss
@@ -1,0 +1,19 @@
+@import '../../../scss/variables';
+@import '../../../scss/media-queries';
+
+.outputs {
+    display: flex;
+    flex: 1;
+    justify-content: center;
+    padding: 40px 60px;
+  
+    @include desktop-down {
+      padding: $spacing-small;
+    }
+  
+    .content {
+      flex: 1;
+      max-width: $content-width-desktop;
+    }
+  }
+  

--- a/src/app/routes/explorer/OutputsRouteProps.ts
+++ b/src/app/routes/explorer/OutputsRouteProps.ts
@@ -1,0 +1,6 @@
+export interface OutputsRouteProps {
+    /**
+     * The tag to lookup.
+     */
+    tag: string;
+}

--- a/src/app/routes/explorer/OutputsRouteState.ts
+++ b/src/app/routes/explorer/OutputsRouteState.ts
@@ -1,0 +1,28 @@
+import { IAssociatedOutput } from "../../../models/tangle/IAssociatedOutputsResponse";
+
+export interface OutputsRouteState {
+    /**
+     * The outputs.
+     */
+    outputs: IAssociatedOutput[];
+
+    /**
+     * The status.
+     */
+    status: string;
+
+    /**
+     * Is the component status busy.
+     */
+    statusBusy: boolean;
+
+    /**
+     * The current page.
+     */
+    currentPage: number;
+
+    /**
+     * The page size.
+     */
+    pageSize: number;
+}

--- a/src/models/IBech32AddressDetails.ts
+++ b/src/models/IBech32AddressDetails.ts
@@ -10,6 +10,11 @@ export interface IBech32AddressDetails {
     hex?: string;
 
     /**
+     * The raw address a hex.
+     */
+    hexNoPrefix?: string;
+
+    /**
      * The raw address type.
      */
     type?: number;

--- a/src/models/tangle/IAssociatedOutputsResponse.ts
+++ b/src/models/tangle/IAssociatedOutputsResponse.ts
@@ -1,0 +1,31 @@
+import { IOutputResponse } from "@iota/iota.js";
+
+export enum AssociationType {
+    BASIC_OUTPUT,
+    BASIC_SENDER,
+    BASIC_EXPIRATION_RETURN,
+    BASIC_STORAGE_RETURN,
+    ALIAS_STATE_CONTROLLER,
+    ALIAS_GOVERNOR,
+    ALIAS_ISSUER,
+    ALIAS_SENDER,
+    FOUNDRY_ALIAS,
+    NFT_OUTPUT,
+    NFT_STORAGE_RETURN,
+    NFT_EXPIRATION_RETURN,
+    NFT_SENDER,
+    TAG
+}
+
+export interface IAssociatedOutput {
+    association: AssociationType;
+    outputId: string;
+    outputDetails?: IOutputResponse;
+}
+
+export interface IAssociatedOutputsResponse {
+    /**
+     * The associated outputs.
+     */
+    outputs?: IAssociatedOutput[];
+}

--- a/src/models/tangle/ISearchRequest.ts
+++ b/src/models/tangle/ISearchRequest.ts
@@ -1,0 +1,16 @@
+export interface ISearchRequest {
+    /**
+     * The query to look for.
+     */
+    query: string;
+
+    /**
+     * The query to look for.
+     */
+    pageSize?: number;
+
+    /**
+     * A cursor to use if reading the next page of results.
+     */
+    cursor?: string;
+}

--- a/src/models/tangle/ISearchResponse.ts
+++ b/src/models/tangle/ISearchResponse.ts
@@ -38,7 +38,17 @@ export interface ISearchResponse {
     output?: IOutputResponse;
 
     /**
+     * Output ids array.
+     */
+    outputs?: string[];
+
+    /**
      * Milestone if it was found.
      */
     milestone?: IMilestonePayload;
+
+    /**
+     * Cursor for next page.
+     */
+    cursor?: string;
 }

--- a/src/utils/bech32AddressHelper.ts
+++ b/src/utils/bech32AddressHelper.ts
@@ -1,5 +1,5 @@
 import { Bech32Helper, ALIAS_ADDRESS_TYPE, ED25519_ADDRESS_TYPE, NFT_ADDRESS_TYPE } from "@iota/iota.js";
-import { Converter } from "@iota/util.js";
+import { Converter, HexHelper } from "@iota/util.js";
 import { IBech32AddressDetails } from "../models/IBech32AddressDetails";
 
 export class Bech32AddressHelper {
@@ -13,6 +13,7 @@ export class Bech32AddressHelper {
     public static buildAddress(address: string, hrp: string, addressType?: number): IBech32AddressDetails {
         let bech32;
         let hex;
+        let hexNoPrefix;
         let type;
 
         if (Bech32Helper.matches(address, hrp)) {
@@ -21,20 +22,23 @@ export class Bech32AddressHelper {
                 if (result) {
                     bech32 = address;
                     type = result.addressType;
-                    hex = Converter.bytesToHex(result.addressBytes);
+                    hex = Converter.bytesToHex(result.addressBytes, true);
+                    hexNoPrefix = HexHelper.stripPrefix(hex);
                 }
             } catch {}
         }
 
         if (!bech32) {
-            type = addressType !== undefined ? addressType : Number.parseInt(address.slice(0, 2), 16);
-            hex = address;
+            hex = HexHelper.addPrefix(address);
+            hexNoPrefix = HexHelper.stripPrefix(address);
+            type = addressType !== undefined ? addressType : ED25519_ADDRESS_TYPE;
             bech32 = Bech32Helper.toBech32(type, Converter.hexToBytes(hex), hrp);
         }
 
         return {
             bech32,
             hex,
+            hexNoPrefix,
             type,
             typeLabel: Bech32AddressHelper.typeLabel(type)
         };

--- a/src/utils/outputsHelper.ts
+++ b/src/utils/outputsHelper.ts
@@ -1,0 +1,159 @@
+import { IndexerPluginClient, IOutputsResponse, IClient } from "@iota/iota.js";
+import { AssociationType, IAssociatedOutput } from "../models/tangle/IAssociatedOutputsResponse";
+
+/**
+ * Helper class to fetch outputs of an query on stardust.
+ */
+export class OutputsHelper {
+    public readonly associatedOutputs: IAssociatedOutput[] = [];
+
+    private readonly query: string;
+
+    private readonly client: IClient;
+
+    constructor(query: string, client: IClient) {
+        this.query = query;
+        this.client = client;
+    }
+
+    public async fetchOutputsByTag() {
+        const indexerPlugin = new IndexerPluginClient(this.client);
+
+        const promises = [
+            this.tryFetchOutputs(
+                async query => indexerPlugin.outputs(query),
+                { tag: this.query },
+                AssociationType.TAG
+            ),
+            this.tryFetchOutputs(
+                async query => indexerPlugin.nfts(query),
+                { tag: this.query },
+                AssociationType.TAG
+            )
+        ];
+        await Promise.all(promises);
+    }
+
+    public async fetchAssociatedOutputs() {
+        const indexerPlugin = new IndexerPluginClient(this.client);
+
+        const promises = [
+            // Basic output
+            this.tryFetchOutputs(
+                async query => indexerPlugin.outputs(query),
+                { addressBech32: this.query },
+                AssociationType.BASIC_OUTPUT
+            ),
+
+            // Basic output -> storage return address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.outputs(query),
+                { storageReturnAddressBech32: this.query },
+                AssociationType.BASIC_STORAGE_RETURN
+            ),
+
+            // Basic output -> expiration return address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.outputs(query),
+                { expirationReturnAddressBech32: this.query },
+                AssociationType.BASIC_EXPIRATION_RETURN
+            ),
+
+            // Basic output -> sender address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.outputs(query),
+                { senderBech32: this.query },
+                AssociationType.BASIC_SENDER
+            ),
+
+            // Alias output -> state controller address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.aliases(query),
+                { stateControllerBech32: this.query },
+                AssociationType.ALIAS_STATE_CONTROLLER
+            ),
+
+            // Alias output -> governor address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.aliases(query),
+                { governorBech32: this.query },
+                AssociationType.ALIAS_GOVERNOR
+            ),
+
+            // Alias output -> issuer address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.aliases(query),
+                { issuerBech32: this.query },
+                AssociationType.ALIAS_ISSUER
+            ),
+
+            // Alias output -> sender address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.aliases(query),
+                { senderBech32: this.query },
+                AssociationType.ALIAS_SENDER
+            ),
+
+            // Foundry output ->  alias address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.foundries(query),
+                { aliasAddressBech32: this.query },
+                AssociationType.FOUNDRY_ALIAS
+            ),
+
+            // Nfts output
+            this.tryFetchOutputs(
+                async query => indexerPlugin.nfts(query),
+                { addressBech32: this.query },
+                AssociationType.NFT_OUTPUT
+            ),
+
+            // Nft output -> storage return address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.nfts(query),
+                { storageReturnAddressBech32: this.query },
+                AssociationType.NFT_STORAGE_RETURN
+            ),
+
+            // Nft output -> expiration return address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.nfts(query),
+                { expirationReturnAddressBech32: this.query },
+                AssociationType.NFT_EXPIRATION_RETURN
+            ),
+
+            // Nft output -> sender address
+            this.tryFetchOutputs(
+                async query => indexerPlugin.nfts(query),
+                { senderBech32: this.query },
+                AssociationType.NFT_SENDER
+            )
+        ];
+
+        await Promise.all(promises);
+    }
+
+
+    private async tryFetchOutputs(
+        fetch: (req: Record<string, unknown>) => Promise<IOutputsResponse>,
+        request: Record<string, unknown>,
+        association: AssociationType
+     ) {
+         const associatedOutputs = this.associatedOutputs;
+         let cursor: string | undefined;
+
+         do {
+             try {
+                 const outputs = await fetch({ ...request, cursor });
+
+                 if (outputs.items.length > 0) {
+                     for (const outputId of outputs.items) {
+                         associatedOutputs.push({ outputId, association });
+                     }
+                 }
+
+                 cursor = outputs.cursor;
+             } catch {}
+         } while (cursor);
+     }
+}

--- a/src/utils/searchQueryBuilder.ts
+++ b/src/utils/searchQueryBuilder.ts
@@ -1,0 +1,153 @@
+import { ALIAS_ADDRESS_TYPE, NFT_ADDRESS_TYPE } from "@iota/iota.js";
+import { Converter, HexHelper } from "@iota/util.js";
+import { IBech32AddressDetails } from "../models/IBech32AddressDetails";
+import { Bech32AddressHelper } from "./bech32AddressHelper";
+
+export interface SearchQuery {
+    /**
+     * The query string in lower case.
+     */
+    queryLower: string;
+    /**
+     * The did query.
+     */
+    did?: string;
+    /**
+     * The milestoneIndex query.
+     */
+    milestoneIndex?: number;
+    /**
+     * The milestoneId query.
+     */
+    milestoneId?: string;
+    /**
+     * The MaybeAddress query.
+     */
+    address?: IBech32AddressDetails;
+    /**
+     * The blockId or transactionId query.
+     */
+    blockIdOrTransactionId?: string;
+    /**
+     * The outputId query.
+     */
+    output?: string;
+    /**
+     * The aliasId query.
+     */
+    aliasId?: string;
+    /**
+     * The nftId query.
+     */
+    nftId?: string;
+    /**
+     * The foundryId query.
+     */
+    foundryId?: string;
+    /**
+     * The tag of an output.
+     */
+    tag?: string;
+}
+
+/**
+ * Builds SearchQuery object from query stirng
+ */
+export class SearchQueryBuilder {
+    /**
+     * The query string.
+     */
+    private readonly query: string;
+
+    /**
+     * The query string in lower case.
+     */
+    private readonly queryLower: string;
+
+    /**
+     * Thed human readable part to use for bech32.
+     */
+    private readonly networkBechHrp: string;
+
+    /**
+     * Creates a new instance of SearchQueryBuilder.
+     * @param query The query string.
+     * @param networkBechHrp The network bechHrp.
+     */
+    constructor(query: string, networkBechHrp: string) {
+        this.query = query;
+        this.queryLower = query.toLowerCase();
+        this.networkBechHrp = networkBechHrp;
+    }
+
+    /**
+     * Builds the SearchQuery.
+     * @returns the SearchQuery object.
+     */
+    public build(): SearchQuery {
+        let blockIdOrTransactionId: string | undefined;
+        let output: string | undefined;
+        let aliasId: string | undefined;
+        let nftId: string | undefined;
+        let milestoneId: string | undefined;
+        let foundryId: string | undefined;
+
+        const milestoneIndex = /^\d+$/.test(this.query) ? Number.parseInt(this.query, 10) : undefined;
+        const address = Bech32AddressHelper.buildAddress(this.query, this.networkBechHrp);
+
+        // if the hex without prefix has 64 characters it might be an AliasId, NftId or MilestoneId
+        if (address?.hexNoPrefix && address.hexNoPrefix.length === 64) {
+            aliasId = address.hex;
+            nftId = address.hex;
+            milestoneId = address.hex;
+        }
+
+        // if the hex without prefix has 66 characters, if might be and Alias or Nft Address
+        if (address?.hexNoPrefix && address.hexNoPrefix.length === 66) {
+            const typeByte = address.hexNoPrefix.slice(0, 2);
+            const maybeAddress = address.hexNoPrefix.slice(2);
+
+            if (Number.parseInt(typeByte, 10) === ALIAS_ADDRESS_TYPE) {
+                aliasId = HexHelper.addPrefix(maybeAddress);
+            }
+
+            if (Number.parseInt(typeByte, 10) === NFT_ADDRESS_TYPE) {
+                nftId = HexHelper.addPrefix(maybeAddress);
+            }
+        }
+
+        const hexWithPrefix = HexHelper.addPrefix(this.queryLower);
+        const hexNoPrefix = HexHelper.stripPrefix(this.queryLower);
+        // if the hex without prefix is 76 characters and first byte is 08,
+        // it can be a FoundryId or TokenId
+        if (Converter.isHex(hexWithPrefix, true) &&
+            Number.parseInt(hexNoPrefix.slice(0, 2), 16) === ALIAS_ADDRESS_TYPE && hexNoPrefix.length === 76) {
+            foundryId = hexWithPrefix;
+        }
+
+        // if the hex has 66 characters, it might be a block or transaction id
+        if (address?.hex && address.hex.length === 66) {
+            blockIdOrTransactionId = address.hex;
+        }
+
+        // if the hex is 70 characters, try and look for an output
+        if (address?.hex && address.hex.length === 70) {
+            output = address.hex;
+        }
+
+        const tag = Converter.isHex(this.query) ? this.query : Converter.utf8ToHex(this.query, true);
+
+        return {
+            queryLower: this.queryLower,
+            milestoneIndex,
+            milestoneId,
+            address,
+            blockIdOrTransactionId,
+            output,
+            aliasId,
+            nftId,
+            foundryId,
+            tag
+        };
+    }
+}


### PR DESCRIPTION
# Description of change

- Pagination fix for small number of pages
- Add pagination to inputs and outputs for transaction payload on Block page
- Fix for fetching all output details on Address page
- Display output tag data hex as readable text
- Display token amounts as numbers
- Add Search Query builder
- Add associated outputs to nft/alias address page
- Add Outputs page
- Remove Balance calculation from address page

This PR aims to fix:
 fixes #112 #119 #130 #131 #137 #138 #139.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
