### PR TITLE
Chore: Bump iota.js dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@iota/iota.js": "^1.9.0-stardust.20",
+                "@iota/iota.js": "^1.9.0-stardust.22",
                 "classnames": "^2.3.1",
                 "humanize-duration": "^3.25.2",
                 "moment": "^2.29.1",
@@ -1968,10 +1968,11 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
         },
         "node_modules/@iota/crypto.js": {
-            "version": "1.9.0-stardust.5",
-            "integrity": "sha512-JEUVZi5GFuaLilNj2C4LP+Ilr6hRtcOrbQTIGf3MVs2ZHDg3NC4E2bNIoMJzdCmxlFyOd1HUr6HyLf+1LBdcDA==",
+            "version": "1.9.0-stardust.6",
+            "resolved": "https://registry.npmjs.org/@iota/crypto.js/-/crypto.js-1.9.0-stardust.6.tgz",
+            "integrity": "sha512-jbruSRXlEKW2dgfPFG7e42ODBp4dVu2/CAh/oZrzMjehPdyF2tgAeN1woOqOAmVONWoGVV9GViZti3nShhGF1g==",
             "dependencies": {
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "big-integer": "^1.6.51"
             },
             "engines": {
@@ -1979,12 +1980,12 @@
             }
         },
         "node_modules/@iota/iota.js": {
-            "version": "1.9.0-stardust.20",
-            "resolved": "https://registry.npmjs.org/@iota/iota.js/-/iota.js-1.9.0-stardust.20.tgz",
-            "integrity": "sha512-F1twnkMxq0twtWLZ30ed3otI35gvHwoWcAKsjW/mHSNFWTWxzkjTlnzJLfDtIr8b1gnO4JTy3cgAJ4kUvgJXDA==",
+            "version": "1.9.0-stardust.22",
+            "resolved": "https://registry.npmjs.org/@iota/iota.js/-/iota.js-1.9.0-stardust.22.tgz",
+            "integrity": "sha512-20hKTqKZ8Gvpe7sQG4k8lEwxbe60/amCCeX/rMuvIb5RAuv4yikl9WFcgRXd9UTQr8D7Pj0rxpMMLZPGa+MGew==",
             "dependencies": {
-                "@iota/crypto.js": "^1.9.0-stardust.5",
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/crypto.js": "^1.9.0-stardust.6",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "big-integer": "^1.6.51",
                 "node-fetch": "2.6.7"
             },
@@ -1993,8 +1994,9 @@
             }
         },
         "node_modules/@iota/util.js": {
-            "version": "1.9.0-stardust.4",
-            "integrity": "sha512-JE6Aew6jI3QqbAP4iu359MgGrf9kcUCDy3f2W2jCDoPYDzlz9eUmVzui16MXTrKHFv7AXaNgKFFuBHyN61RuJA==",
+            "version": "1.9.0-stardust.5",
+            "resolved": "https://registry.npmjs.org/@iota/util.js/-/util.js-1.9.0-stardust.5.tgz",
+            "integrity": "sha512-BGXzzjUQQYaV/H0bXJYKW+Zgd9PIN+HLPH8BcYhubI65X4G2ID23/osmpK/za+Ds6t/MkpdPKIiBwZPGXuCUBw==",
             "dependencies": {
                 "big-integer": "^1.6.51"
             },
@@ -4962,6 +4964,7 @@
         },
         "node_modules/big-integer": {
             "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
             "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
             "engines": {
                 "node": ">=0.6"
@@ -23254,27 +23257,29 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
         },
         "@iota/crypto.js": {
-            "version": "1.9.0-stardust.5",
-            "integrity": "sha512-JEUVZi5GFuaLilNj2C4LP+Ilr6hRtcOrbQTIGf3MVs2ZHDg3NC4E2bNIoMJzdCmxlFyOd1HUr6HyLf+1LBdcDA==",
+            "version": "1.9.0-stardust.6",
+            "resolved": "https://registry.npmjs.org/@iota/crypto.js/-/crypto.js-1.9.0-stardust.6.tgz",
+            "integrity": "sha512-jbruSRXlEKW2dgfPFG7e42ODBp4dVu2/CAh/oZrzMjehPdyF2tgAeN1woOqOAmVONWoGVV9GViZti3nShhGF1g==",
             "requires": {
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "big-integer": "^1.6.51"
             }
         },
         "@iota/iota.js": {
-            "version": "1.9.0-stardust.20",
-            "resolved": "https://registry.npmjs.org/@iota/iota.js/-/iota.js-1.9.0-stardust.20.tgz",
-            "integrity": "sha512-F1twnkMxq0twtWLZ30ed3otI35gvHwoWcAKsjW/mHSNFWTWxzkjTlnzJLfDtIr8b1gnO4JTy3cgAJ4kUvgJXDA==",
+            "version": "1.9.0-stardust.22",
+            "resolved": "https://registry.npmjs.org/@iota/iota.js/-/iota.js-1.9.0-stardust.22.tgz",
+            "integrity": "sha512-20hKTqKZ8Gvpe7sQG4k8lEwxbe60/amCCeX/rMuvIb5RAuv4yikl9WFcgRXd9UTQr8D7Pj0rxpMMLZPGa+MGew==",
             "requires": {
-                "@iota/crypto.js": "^1.9.0-stardust.5",
-                "@iota/util.js": "^1.9.0-stardust.4",
+                "@iota/crypto.js": "^1.9.0-stardust.6",
+                "@iota/util.js": "^1.9.0-stardust.5",
                 "big-integer": "^1.6.51",
                 "node-fetch": "2.6.7"
             }
         },
         "@iota/util.js": {
-            "version": "1.9.0-stardust.4",
-            "integrity": "sha512-JE6Aew6jI3QqbAP4iu359MgGrf9kcUCDy3f2W2jCDoPYDzlz9eUmVzui16MXTrKHFv7AXaNgKFFuBHyN61RuJA==",
+            "version": "1.9.0-stardust.5",
+            "resolved": "https://registry.npmjs.org/@iota/util.js/-/util.js-1.9.0-stardust.5.tgz",
+            "integrity": "sha512-BGXzzjUQQYaV/H0bXJYKW+Zgd9PIN+HLPH8BcYhubI65X4G2ID23/osmpK/za+Ds6t/MkpdPKIiBwZPGXuCUBw==",
             "requires": {
                 "big-integer": "^1.6.51"
             }
@@ -25447,6 +25452,7 @@
         },
         "big-integer": {
             "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
             "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
         },
         "big.js": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "homepage": "/dashboard",
     "license": "MIT",
     "dependencies": {
-        "@iota/iota.js": "^1.9.0-stardust.20",
+        "@iota/iota.js": "^1.9.0-stardust.22",
         "classnames": "^2.3.1",
         "humanize-duration": "^3.25.2",
         "moment": "^2.29.1",

--- a/src/services/nodeConfigService.ts
+++ b/src/services/nodeConfigService.ts
@@ -57,7 +57,7 @@ export class NodeConfigService {
 
             try {
                 const info = await tangleService.info();
-                this.setBech32Hrp(info.protocol.bech32HRP);
+                this.setBech32Hrp(info.protocol.bech32Hrp);
                 this.setNetworkId(info.protocol.networkName);
                 this.setBaseToken(info.baseToken);
             } catch {}

--- a/src/services/tangleService.ts
+++ b/src/services/tangleService.ts
@@ -60,7 +60,7 @@ export class TangleService {
         if (!this._nodeInfo) {
             await this.info();
         }
-        const bech32HRP = this._nodeInfo ? this._nodeInfo.protocol.bech32HRP : Bech32Helper.BECH32_DEFAULT_HRP_MAIN;
+        const bech32HRP = this._nodeInfo ? this._nodeInfo.protocol.bech32Hrp : Bech32Helper.BECH32_DEFAULT_HRP_MAIN;
         const searchQuery: SearchQuery = new SearchQueryBuilder(request.query, bech32HRP).build();
 
         if (searchQuery.milestoneIndex) {


### PR DESCRIPTION
# Description of change

- Bumped iota.js dep to `1.9.0-stardust.22`
- Fixed renamed fields issues

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
