### PR TITLE
Feat: Add value spam option to Spammer plugin

### DIFF
--- a/src/app/components/plugins/Spammer.tsx
+++ b/src/app/components/plugins/Spammer.tsx
@@ -21,7 +21,7 @@ class Spammer extends AsyncComponent<unknown, SpammerState> {
     /**
      * The description of the plugin.
      */
-    private static readonly PLUGIN_DESCRIPTION = "Spam the IOTA network with data blocks.";
+    private static readonly PLUGIN_DESCRIPTION = "Spam the network with tagged data or transaction payloads.";
 
     /**
      * Is the spammer plugin available.
@@ -40,7 +40,8 @@ class Spammer extends AsyncComponent<unknown, SpammerState> {
             bps: "1",
             cpu: "80",
             workers: "0",
-            workersMax: 0
+            workersMax: 0,
+            valueSpamEnabled: false
         };
     }
 
@@ -133,6 +134,15 @@ class Spammer extends AsyncComponent<unknown, SpammerState> {
                     </div>
                     <h2 className="margin-t-s">Settings</h2>
                     <div className="card--label">
+                        Enable value spam
+                    </div>
+                    <div className="card--value row">
+                        <ToggleButton
+                            value={this.state.valueSpamEnabled}
+                            onChanged={value => this.setState({ valueSpamEnabled: value })}
+                        />
+                    </div>
+                    <div className="card--label">
                         Blocks Per Second
                     </div>
                     <div className="card--value row">
@@ -205,7 +215,8 @@ class Spammer extends AsyncComponent<unknown, SpammerState> {
                     bps: response.bpsRateLimit.toString(),
                     cpu: (response.cpuMaxUsage * 100).toString(),
                     workers: response.spammerWorkers.toString(),
-                    workersMax: response.spammerWorkersMax
+                    workersMax: response.spammerWorkersMax,
+                    valueSpamEnabled: response.valueSpamEnabled
                 });
             } else {
                 console.log("loging eror", response.error);
@@ -251,7 +262,8 @@ class Spammer extends AsyncComponent<unknown, SpammerState> {
                 {
                     bpsRateLimit: Number.parseFloat(this.state.bps),
                     cpuMaxUsage: Number.parseFloat(this.state.cpu) / 100,
-                    spammerWorkers: Number.parseInt(this.state.workers, 10)
+                    spammerWorkers: Number.parseInt(this.state.workers, 10),
+                    valueSpamEnabled: this.state.valueSpamEnabled
                 },
                 Spammer.buildAuthHeaders());
 

--- a/src/app/components/plugins/SpammerState.ts
+++ b/src/app/components/plugins/SpammerState.ts
@@ -24,4 +24,9 @@ export interface SpammerState {
      * Spam Workers max.
      */
     workersMax: number;
+
+    /**
+     * Is value spamming enabled.
+     */
+    valueSpamEnabled: boolean;
 }

--- a/src/models/plugins/ISpammerSettings.ts
+++ b/src/models/plugins/ISpammerSettings.ts
@@ -25,6 +25,11 @@ export interface ISpammerSettings {
     spammerWorkersMax: number;
 
     /**
+     * Is value spamming enabled.
+     */
+    valueSpamEnabled: boolean;
+
+    /**
      * The error messsage.
      */
     error?: {


### PR DESCRIPTION
# Description of change

Added value spam option to Spammer plugin to enable spamming the network with blocks that have transaction payload.
fixes #171 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)



## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
