### PR TITLE
feat: Add copy buttons for peer id and address

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1030,7 +1030,7 @@ module.exports = {
             "error"
         ],
         "operator-linebreak": [
-            "error"
+            "error", "after", { "overrides": { "?": "ignore", ":": "ignore" } }
         ],
         "padded-blocks": [
             "error",

--- a/src/app/routes/Peer.scss
+++ b/src/app/routes/Peer.scss
@@ -35,6 +35,11 @@
         flex-direction: column;
         justify-content: space-between;
         padding: $spacing-small;
+
+        .block-button .block-button-btn svg {
+            width: 16px;
+            height: 16px;
+        }
       }
 
       .health-indicators {

--- a/src/app/routes/Peer.tsx
+++ b/src/app/routes/Peer.tsx
@@ -12,8 +12,10 @@ import { ISyncStatus } from "../../models/websocket/ISyncStatus";
 import { WebSocketTopic } from "../../models/websocket/webSocketTopic";
 import { MetricsService } from "../../services/metricsService";
 import { SettingsService } from "../../services/settingsService";
+import { ClipboardHelper } from "../../utils/clipboardHelper";
 import { DataHelper } from "../../utils/dataHelper";
 import AsyncComponent from "../components/layout/AsyncComponent";
+import BlockButton from "../components/layout/BlockButton";
 import Graph from "../components/layout/Graph";
 import HealthIndicator from "../components/layout/HealthIndicator";
 import InfoPanel from "../components/layout/InfoPanel";
@@ -234,20 +236,59 @@ class Peer extends AsyncComponent<RouteComponentProps<PeerRouteProps>, PeerState
                                         <h2 className="word-break-all">{this.state.blindMode
                                             ? "*".repeat(this.state.alias.length) : this.state.alias}
                                         </h2>
-                                        <p className="secondary margin-t-t">{this.state.blindMode
-                                            ? "*".repeat(this.props.match.params.id.length)
-                                            : this.props.match.params.id}
-                                        </p>
+                                        <span className="row bottom">
+                                            <p className="secondary margin-t-t">{this.state.blindMode
+                                                ? "*".repeat(this.props.match.params.id.length)
+                                                : this.props.match.params.id}
+                                            </p>
+                                            <div className="margin-l-t">
+                                                <BlockButton
+                                                    onClick={() => ClipboardHelper.copy(this.props.match.params.id)}
+                                                    buttonType="copy"
+                                                    labelPosition="right"
+                                                />
+                                            </div>
+                                        </span>
                                     </React.Fragment>
                                 )}
                                 {!this.state.alias && (
-                                    <h2 className="word-break-all">{this.state.blindMode
-                                        ? "*".repeat(this.props.match.params.id.length) : this.props.match.params.id}
-                                    </h2>
+                                    <span className="row bottom">
+                                        <h2 className="word-break-all">{
+                                            this.state.blindMode ?
+                                                "*".repeat(this.props.match.params.id.length) :
+                                                this.props.match.params.id
+                                            }
+                                        </h2>
+                                        <div className="margin-l-t">
+                                            <BlockButton
+                                                onClick={() => ClipboardHelper.copy(this.props.match.params.id)}
+                                                buttonType="copy"
+                                                labelPosition="right"
+                                            />
+                                        </div>
+                                    </span>
                                 )}
-                                <p className="secondary margin-t-t">{this.state.blindMode
-                                    ? "*".repeat(this.state.address.length) : this.state.address}
-                                </p>
+                                <span className="row bottom">
+                                    <p className="secondary margin-t-t">{this.state.blindMode
+                                        ? "*".repeat(this.state.address.length) : this.state.address}
+                                    </p>
+                                    {this.state.address.length > 0 && (
+                                        <div className="margin-l-t">
+                                            <BlockButton
+                                                onClick={() => {
+                                                    const parts = this.state.address.split(":");
+                                                    if (parts.length === 2) {
+                                                        ClipboardHelper.copy(`/ip4/${parts[0]}/tcp/${parts[1]}`);
+                                                    } else {
+                                                        ClipboardHelper.copy(this.state.address);
+                                                    }
+                                                }}
+                                                buttonType="copy"
+                                                labelPosition="right"
+                                            />
+                                        </div>
+                                    )}
+                                </span>
                                 <p className="secondary margin-t-t">
                                     Relation:&nbsp;
                                     {`${this.state.relation.slice(0, 1).toUpperCase()}${this.state.relation.slice(1)}`}


### PR DESCRIPTION
# Description of change

- Added convenience copy buttons for peer id and peer address (copies to `/ip4/{ip}/tcp/{port} format) to Peer details page

Resolves https://github.com/iotaledger/node-dashboard/issues/35

## Type of change

- Enhancement (a non-breaking change which adds functionality)

