### PR TITLE
Feat: Refresh token automatically before it expires.

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -481,8 +481,7 @@ class App extends AsyncComponent<RouteComponentProps, AppState> {
             this._tokenExpiryTimer = undefined;
         }
         const jwt = this._storageService.load<string>("dashboard-jwt");
-        const decodedJwt = this.decodeToken(jwt);
-        const expiryTime = decodedJwt.exp * 1000;
+        const expiryTime = this.getTokenExpiry(jwt);
 
         this._tokenExpiryTimer = setInterval(async () => {
             if (expiryTime < moment().valueOf()) {
@@ -498,13 +497,15 @@ class App extends AsyncComponent<RouteComponentProps, AppState> {
     /**
      * Decode jwt to get expiry time.
      * @param token The jwt.
-     * @returns The decoded jwt.
+     * @returns The expiry time.
      */
-    private decodeToken(token: string) {
+    private getTokenExpiry(token: string) {
         const payload = token.split(".")[1];
-        const decodedJwt = window.atob(payload);
+        const decodedToken = window.atob(payload);
+        const parsedToken = JSON.parse(decodedToken);
+        const expiryTime = parsedToken.exp * 1000;
 
-        return JSON.parse(decodedJwt);
+        return expiryTime;
     }
 }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -52,11 +52,6 @@ import Unavailable from "./routes/Unavailable";
 import Visualizer from "./routes/Visualizer";
 
 /**
- * Milliseconds in a minute
- */
-const MILLI_SECONDS_IN_ONE_MINUTE = 60000;
-
-/**
  * Main application class.
  */
 class App extends AsyncComponent<RouteComponentProps, AppState> {
@@ -476,12 +471,15 @@ class App extends AsyncComponent<RouteComponentProps, AppState> {
         this.clearTokenExpiryInterval();
         const jwt = this._storageService.load<string>("dashboard-jwt");
         const expiryTimestamp = this.getTokenExpiry(jwt);
+        const expiryDate = moment(expiryTimestamp);
+        const refreshTokenDate = moment(expiryDate).subtract(1, "minutes");
 
         this._tokenExpiryTimer = setInterval(async () => {
-            if (moment(expiryTimestamp).isBefore(moment())) {
+            const now = moment();
+            if (now.isAfter(expiryDate)) {
                 this._authService.logout();
                 this.clearTokenExpiryInterval();
-            } else if (moment(expiryTimestamp).isBefore(moment().valueOf() + MILLI_SECONDS_IN_ONE_MINUTE)) {
+            } else if (now.isBetween(refreshTokenDate, expiryDate)) {
                 await this._authService.initialize();
             }
         }, 5000);


### PR DESCRIPTION
# Description of change

- Add function to validate token periodically.
- Logout user if the expiry time exceeds (If the system is on sleep).
- Refresh token 1 minute before it expires.

Resolves https://github.com/iotaledger/node-dashboard/issues/65

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
